### PR TITLE
Various fixes

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -28,7 +28,7 @@
 #define    MAX_HIGH_PRESSURE_DAMAGE 4 // This used to be 20... I got this much random rage for some retarded decision by polymorph?! Polymorph now lies in a pool of blood with a katana jammed in his spleen. ~Errorage --PS: The katana did less than 20 damage to him :(
 #define         LOW_PRESSURE_DAMAGE 2 // The amount of damage someone takes when in a low pressure area. (The pressure threshold is so low that it doesn't make sense to do any calculations, so it just applies this flat value).
 
-#define MINIMUM_AIR_RATIO_TO_SUSPEND 0.05 // Minimum ratio of air that must move to/from a tile to suspend group processing
+#define MINIMUM_AIR_RATIO_TO_SUSPEND 0.02 // Minimum ratio of air that must move to/from a tile to suspend group processing
 #define MINIMUM_AIR_TO_SUSPEND       (MOLES_CELLSTANDARD * MINIMUM_AIR_RATIO_TO_SUSPEND) // Minimum amount of air that has to move before a group processing can be suspended
 #define MINIMUM_MOLES_DELTA_TO_MOVE  (MOLES_CELLSTANDARD * MINIMUM_AIR_RATIO_TO_SUSPEND) // Either this must be active
 #define MINIMUM_TEMPERATURE_TO_MOVE  (T20C + 100)                                        // or this (or both, obviously)

--- a/code/game/objects/items/weapons/job_items/tape_rolls.dm
+++ b/code/game/objects/items/weapons/job_items/tape_rolls.dm
@@ -16,6 +16,7 @@ var/list/tape_roll_applications = list()
 	name = "tape"
 	icon = 'icons/policetape.dmi'
 	anchored = 1
+	layer = 3.2
 	var/lifted = 0
 	var/crumpled = 0
 	var/tape_dir = 0

--- a/code/modules/europa/clothing/helmet.dm
+++ b/code/modules/europa/clothing/helmet.dm
@@ -29,6 +29,7 @@
 	desc = "A light diving helmet suitable for shallow excursions."
 	icon_state = "diving_light"
 	light_overlay = "hardhat_light"
+	flags_inv = HIDEMASK | HIDEEARS | HIDEEYES | BLOCKHAIR
 
 /obj/item/clothing/head/helmet/space/europa/diving/medium
 	name = "reinforced diving helmet"


### PR DESCRIPTION
 - Fixes #280 

Due to Linda being "lazy" it needs a lower suspend ratio, otherwise it stops before the room is properly depressurized, resulting in 5kPa differences between turfs next to each other. This meant unless an air alarm was on top of an air scrubber it would never be able to finish a siphon cycle.

Also fixed mapped in engineering tape being rendered under airlocks.

 - Fixes #197 

There are likely to be more missing hide tags on items, but I'm not personally going to test every single item.