### PR TITLE
Helmet overlay runtime fix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -347,7 +347,7 @@ BLIND     // can't see anything
 		var/cache_key = "[light_overlay][H ? "_[H.species.get_bodytype()]" : ""]"
 		if(!light_overlay_cache[cache_key])
 			var/use_icon = 'icons/mob/light_overlays.dmi'
-			if(H && sprite_sheets[H.species.get_bodytype()])
+			if(H && sprite_sheets && sprite_sheets[H.species.get_bodytype()])
 				use_icon = sprite_sheets[H.species.get_bodytype()]
 			light_overlay_cache[cache_key] = image("icon" = use_icon, "icon_state" = "[light_overlay]")
 


### PR DESCRIPTION
Fixes a bad index runtime when helmets have no sprite_sheets list.