### PR TITLE
Ocean depth defines

### DIFF
--- a/code/__defines/europa.dm
+++ b/code/__defines/europa.dm
@@ -11,3 +11,7 @@
 #define MEDSCI 2
 #define ENGSEC 3
 #define SHEET_MATERIAL_AMOUNT 2750
+
+//depth in bars (each bar is 1 atmosphere and approximately 10 meters)
+#define OCEAN_DEPTH 15
+#define OCEAN_PRESSURE (OCEAN_DEPTH * ONE_ATMOSPHERE)


### PR DESCRIPTION
Just a couple of defines for working with the ocean depth. 

Useful for setting things like airlock target pressure.