### PR TITLE
Piercing wounds

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -9,6 +9,7 @@
 
 #define CUT       "cut"
 #define BRUISE    "bruise"
+#define PIERCE    "pierce"
 
 #define STUN      "stun"
 #define WEAKEN    "weaken"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -72,7 +72,7 @@
 	user.visible_message("<span class='notice'>\The [user] starts examining [M]'s [affecting.name].</span>")
 	var/warn_too_big
 	for(var/datum/wound/W in affecting.wounds)
-		if(W.internal || W.bandaged || W.damage_type != CUT)
+		if(W.internal || W.bandaged || !W.open)
 			continue
 		if(W.damage >= W.autoheal_cutoff)
 			if(!warn_too_big)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -96,7 +96,7 @@
 		return 0
 	var/result
 	for(var/datum/wound/W in wounds)
-		if(W.damage_type == CUT && !W.internal && !W.bandaged)
+		if(W.open && !W.internal && !W.bandaged)
 			result = 1
 			if(!open)
 				open = 1
@@ -265,7 +265,10 @@
 	if(is_damageable(brute + burn) || !config.limbs_can_break)
 		if(brute)
 			if(can_cut)
-				createwound( CUT, brute )
+				if(sharp && !edge)
+					createwound( PIERCE, brute )
+				else
+					createwound( CUT, brute )
 			else
 				createwound( BRUISE, brute )
 		if(burn)
@@ -279,7 +282,10 @@
 			if (brute > 0)
 				//Inflict all burte damage we can
 				if(can_cut)
-					createwound( CUT, min(brute,can_inflict) )
+					if(sharp && !edge)
+						createwound( PIERCE, min(brute,can_inflict) )
+					else
+						createwound( CUT, min(brute,can_inflict) )
 				else
 					createwound( BRUISE, min(brute,can_inflict) )
 				var/temp = can_inflict
@@ -347,10 +353,10 @@
 			break
 
 		// heal brute damage
-		if(W.damage_type == CUT || W.damage_type == BRUISE)
-			brute = W.heal_damage(brute)
-		else if(W.damage_type == BURN)
+		if(W.damage_type == BURN)
 			burn = W.heal_damage(burn)
+		else
+			brute = W.heal_damage(brute)
 
 	if(internal)
 		status &= ~ORGAN_BROKEN
@@ -670,10 +676,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	//update damage counts
 	for(var/datum/wound/W in wounds)
 		if(!W.internal) //so IB doesn't count towards crit/paincrit
-			if(W.damage_type == CUT || W.damage_type == BRUISE)
-				brute_dam += W.damage
-			else if(W.damage_type == BURN)
+			if(W.damage_type == BURN)
 				burn_dam += W.damage
+			else
+				brute_dam += W.damage
 
 		if(!(status & ORGAN_ROBOT) && W.bleeding() && (H && H.should_have_organ(O_HEART)))
 			W.bleed_timer--

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -43,7 +43,7 @@
 	// whether this wound needs a bandage/salve to heal at all
 	// the maximum amount of damage that this wound can have and still autoheal
 	var/autoheal_cutoff = 15
-
+	var/open = 0
 
 
 
@@ -211,7 +211,7 @@
 		if (wound_damage() <= 30 && bleed_timer <= 0)
 			return 0	//Bleed timer has run out. Wounds with more than 30 damage don't stop bleeding on their own.
 
-		return (damage_type == BRUISE && wound_damage() >= 20 || damage_type == CUT && wound_damage() >= 5)
+		return 1
 
 /** WOUND DEFINITIONS **/
 
@@ -235,6 +235,18 @@
 					return /datum/wound/cut/deep
 				if(0 to 15)
 					return /datum/wound/cut/small
+		if(PIERCE)
+			switch(damage)
+				if(40 to INFINITY)
+					return /datum/wound/puncture/massive
+				if(30 to 40)
+					return /datum/wound/puncture/gaping_big
+				if(20 to 30)
+					return /datum/wound/puncture/gaping
+				if(10 to 20)
+					return /datum/wound/puncture/flesh
+				if(0 to 10)
+					return /datum/wound/puncture/small
 		if(BRUISE)
 			return /datum/wound/bruise
 		if(BURN)
@@ -252,6 +264,10 @@
 	return null //no wound
 
 /** CUTS **/
+/datum/wound/cut/open = 1
+/datum/wound/cut/bleeding()
+	return ..() && wound_damage() >= 5
+
 /datum/wound/cut/small
 	// link wound descriptions to amounts of damage
 	// Minor cuts have max_bleeding_stage set to the stage that bears the wound type's name.
@@ -285,7 +301,44 @@ datum/wound/cut/massive
 	stages = list("massive wound" = 70, "massive healing wound" = 50, "massive blood soaked clot" = 25, "massive angry scar" = 10,  "massive jagged scar" = 0)
 	damage_type = CUT
 
+/** PUNCTURES  **/
+/datum/wound/puncture/open = 1
+/datum/wound/puncture/can_worsen(damage_type, damage)
+	return 0
+/datum/wound/puncture/can_merge(var/datum/wound/other)
+	return 0
+/datum/wound/puncture/bleeding()
+	return ..() && wound_damage() >= 5
+
+/datum/wound/puncture/small
+	max_bleeding_stage = 2
+	stages = list("puncture" = 5, "healing puncture" = 2, "small scab" = 0)
+	damage_type = PIERCE
+
+/datum/wound/puncture/flesh
+	max_bleeding_stage = 2
+	stages = list("puncture wound" = 10, "blood soaked clot" = 5, "large scab" = 2, "small round scar" = 0)
+	damage_type = PIERCE
+
+/datum/wound/puncture/gaping
+	max_bleeding_stage = 3
+	stages = list("gaping hole" = 20, "large blood soaked clot" = 15, "blood soaked clot" = 10, "small angry scar" = 5, "small round scar" = 0)
+	damage_type = PIERCE
+
+/datum/wound/puncture/gaping_big
+	max_bleeding_stage = 3
+	stages = list("big gaping hole" = 30, "healing gaping hole" = 20, "large blood soaked clot" = 15, "large angry scar" = 10, "large round scar" = 0)
+	damage_type = PIERCE
+
+datum/wound/puncture/massive
+	max_bleeding_stage = 3
+	stages = list("massive wound" = 40, "massive healing wound" = 30, "massive blood soaked clot" = 25, "massive angry scar" = 10,  "massive jagged scar" = 0)
+	damage_type = PIERCE
+
 /** BRUISES **/
+/datum/wound/bruise/bleeding()
+	return ..() && wound_damage() >= 20
+
 /datum/wound/bruise
 	stages = list("monumental bruise" = 80, "huge bruise" = 50, "large bruise" = 30,
 				  "moderate bruise" = 20, "small bruise" = 10, "tiny bruise" = 5)
@@ -294,6 +347,9 @@ datum/wound/cut/massive
 	damage_type = BRUISE
 
 /** BURNS **/
+/datum/wound/burn/bleeding()
+	return 0
+
 /datum/wound/burn/moderate
 	stages = list("ripped burn" = 10, "moderate burn" = 5, "healing moderate burn" = 2, "fresh skin" = 0)
 	damage_type = BURN

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -134,7 +134,7 @@
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
 	check_armour = "melee"
-	damage = 10
+	damage = 5
 	agony = 25
 	embed = 0
 	sharp = 0

--- a/code/modules/surgery/suture_wounds.dm
+++ b/code/modules/surgery/suture_wounds.dm
@@ -14,7 +14,7 @@
 	if(!affected || affected.is_stump() || (affected.status & ORGAN_ROBOT))
 		return 0
 	for(var/datum/wound/W in affected.wounds)
-		if(!W.internal && W.damage_type == CUT && W.damage >= 10)
+		if(!W.internal && W.open && W.damage >= W.autoheal_cutoff)
 			return 1
 	return 0
 
@@ -29,7 +29,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/found_wound
 	for(var/datum/wound/W in affected.wounds)
-		if(!W.internal && W.damage_type == CUT && W.damage >= 10)
+		if(!W.internal && W.open && W.damage >= W.autoheal_cutoff)
 			// Close it up to a point that it can be bandaged and heal naturally!
 			W.heal_damage(rand(10,20)+10)
 			if(W.damage <= 10)


### PR DESCRIPTION
Adds new type of wounds - piercing.
Those are caused by sharp things without the edge, namely bullets.
Unlike other wounds, they do not merge together, so if you empty .38 in a guy, he'll have 6 .38 holes instead of one megawound. Get a shotgun if you want one.

Touched code all over the place to make stuff recognize new type.
Added new var for wounds - open, since damtype checks were getting wordy.
Cleaned up bleeding() proc a bit with power of OOP.