### PR TITLE
Fixed snake tail movement

### DIFF
--- a/code/modules/mob/living/carbon/human/human_tail.dm
+++ b/code/modules/mob/living/carbon/human/human_tail.dm
@@ -151,7 +151,7 @@ var/list/human_tail_cache = list()
 /obj/effect/tail/trailing
 	name = "tail"
 	var/terminating
-	animate_movement = SLIDE_STEPS
+	animate_movement = SYNC_STEPS
 
 /obj/effect/tail/trailing/New(var/newloc, var/term)
 	terminating = term


### PR DESCRIPTION
Stops the tail segments from getting out of time with the parent mob.

There's still some separation when going around corners, but at least this stops the "wobble effect" when moving in a straight line.