### PR TITLE
Adds a new Server Info window

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1696,6 +1696,7 @@
 #include "code\modules\mob\new_player\new_player.dm"
 #include "code\modules\mob\new_player\poll.dm"
 #include "code\modules\mob\new_player\preferences_setup.dm"
+#include "code\modules\mob\new_player\server_info_window.dm"
 #include "code\modules\mob\new_player\sprite_accessories.dm"
 #include "code\modules\mob\observer\observer.dm"
 #include "code\modules\mob\observer\freelook\chunk.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -103,6 +103,8 @@ var/list/gamemode_cache = list()
 	var/wikiurl
 	var/forumurl
 	var/githuburl
+	var/upstreamurl
+	var/upstream
 
 	//Alert level description
 	var/alert_desc_green = "All threats have passed. Crew may not have weapons visible, privacy laws are once again fully enforced."
@@ -431,6 +433,12 @@ var/list/gamemode_cache = list()
 
 				if ("githuburl")
 					config.githuburl = value
+
+				if ("upstreamurl")
+					config.upstreamurl = value
+
+				if ("upstream")
+					config.upstream = value
 
 				if ("ghosts_can_possess_animals")
 					config.ghosts_can_possess_animals = value

--- a/code/global.dm
+++ b/code/global.dm
@@ -95,6 +95,8 @@ var/list/IClog     = list()
 var/list/OOClog    = list()
 var/list/adminlog  = list()
 
+var/list/acceptedKeys = list() //A list of ckeys that have viewed the intro-screen this round and accepted joining.
+
 var/list/powernets = list()
 
 var/Debug2 = 0

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -18,6 +18,8 @@
 
 	var/adminhelped = 0
 
+	var/datum/browser/infowindow
+
 		///////////////
 		//SOUND STUFF//
 		///////////////

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -23,8 +23,6 @@
 
 /mob/new_player/Login()
 	update_Login_details()	//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
-	if(join_motd)
-		src << "<div class=\"motd\">[join_motd]</div>"
 	src << "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>"
 
 	if(!mind)
@@ -38,7 +36,10 @@
 	sight |= SEE_TURFS
 	player_list |= src
 
-	new_player_panel()
+	if (client.ckey in acceptedKeys) //Check if they've already clicked the I ACCEPT info window thing, each round once.
+		new_player_panel()
+	else
+		client.check_server_info()
 	spawn(40)
 		if(client)
 			handle_privacy_poll()

--- a/code/modules/mob/new_player/server_info_window.dm
+++ b/code/modules/mob/new_player/server_info_window.dm
@@ -1,0 +1,58 @@
+/client/verb/check_server_info()
+	set name = "Server Information"
+	set category = "OOC"
+
+	if (src.infowindow)  //If the user's already viewed the window before just load it again.
+		src.infowindow.open()
+		return
+
+	var/list/close = list("Gotcha!","AFFIRMATIVE","EXCELSIOR!","I accept","The Pact Is Sealed","Continue","Take me to the fun!","Let us begin")
+	var/output = {"
+	[join_motd]
+	<br>
+	[file2text("config/rules.html")]
+	<p><b>Map info:</b></p>
+	[using_map.motd]
+	<br>
+	<br>
+	<div align='center'>
+	<strong>Useful links:</strong>
+	<br>
+	<b><a href='byond://?src=\ref[src];bugtracker_link=1'>Bugtracker</A></b>
+	<b><a href='byond://?src=\ref[src];wiki_link=1'>Wiki</A></b>
+	<b><a href='byond://?src=\ref[src];forum_link=1'>Forum</A></b>
+	<b><a href='byond://?src=\ref[src];changelog_link=1'>Changelog</A></b>
+	<br>
+	This server is running the [game_version] modification of <a href='byond://?src=\ref[src];upstream_link=1'>[config.upstream]</A>'s SS13 code.
+	<p><b><a href='byond://?src=\ref[src];close_info=1'>[pick(close)]</A></b></p>
+	</div>"}
+	infowindow = new(src.mob, "Welcome to [game_version]","Welcome to [game_version]", 768, 768, src)
+	infowindow.set_window_options("can_close=0")
+	infowindow.set_content(output)
+	infowindow.open()
+	return
+
+client/Topic(href, href_list[])
+	if(href_list["upstream_link"])
+		src << link(config.upstreamurl)
+
+	if (href_list["bugtracker_link"])
+		src << link(config.githuburl)
+
+	if(href_list["wiki_link"])
+		src.wiki()
+
+	if(href_list["forum_link"])
+		src.forum()
+
+	if(href_list["changelog_link"])
+		src.changes()
+
+	if(href_list["close_info"])
+		src.infowindow.close()
+		if(isnewplayer(src.mob))
+			var/mob/new_player/M = src.mob
+			if(!(src.ckey in acceptedKeys)) //If they've yet to view the info window they must be just joining so we note this then show them the normal menu.
+				M.new_player_panel()
+				acceptedKeys.Add(src.ckey)
+	..()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -210,6 +210,12 @@ GUEST_BAN
 ## GitHub address
 # GITHUBURL https://github.com/example-user/example-repository
 
+## Upstream Github address - just for things like "This is a modified fork of [Baystation]"
+# UPSTREAMURL https://github.com/example-user/example-repository
+
+## Upstream name
+# UPSTREAM Baystation12
+
 ## Ban appeals URL - usually for a forum or wherever people should go to contact your admins.
 # BANAPPEALS http://example.com
 

--- a/config/example/motd.txt
+++ b/config/example/motd.txt
@@ -1,7 +1,7 @@
-<h1>Welcome to Europa, colonist.</h1>
+<div align='center'><h1>Welcome to Europa, colonist.</h1></div>
+<br>
+<div>
+<strong>By continuing you agree to read the rules below</strong> and get familiar with our roleplaying expectations before diving in.
+</div>
 
--<i>This server is running the Europa Station 13 modification of <a href="http://baystation12.net/">Baystation 12's</a> SS13 code.</i>
 <br>
-Please check over the rules and get familiar with our roleplaying expectations before you dive in.
-<br>
-<strong>Bugtracker:</strong> <a href="https://github.com/Yonaguni/Baystation12/issues">for posting of bugs and issues.</a>

--- a/config/example/rules.html
+++ b/config/example/rules.html
@@ -1,25 +1,15 @@
-<html>
-<head><title>Server Rules</title></head>
-<body>
-
-<table width = '100%'>
-<tr height = '80px'><td>
-- <b>No mass-murder, bombings, floodings, etc by non-antagonists.</b> This is griefing and will be dealt with accordingly.
-</tr></td>
-<tr height = '80px'><td>
-- <b>RP is enforced. No netspeak, meme spam, blatant OOC in IC, metagaming, metacommunications or patently absurd character concepts.</b> This -is- SS13, so some leeway for strange or surreal concepts is allowed, but if you are unclear on something in this list, ask an admin.
-</tr></td>
-<tr height = '80px'><td>
-- <b>No ERP (cybersex).</b> This extends to excessive public displays of affection like making out or grinding. We don't care how realistic it is for people on a colony to bump uglies.
-</tr></td>
-<tr height = '80px'><td>
-- <b>You are expected to be competent at a job that you sign up for.</b> This doesn't mean people learning a job are unwelcome, but if you join as a doctor with no understanding of any aspect of medicine you can expect a jobban.
-</tr></td>
-<tr height = '80px'><td>
-- <b>Racism, sexism, questionable content and spamming on OOC mediums are not appreciated.</b> If you're saying something you wouldn't in public, do it at your own peril.
-</tr></td>
-<tr height = '80px'><td>
-- <b>Admins reserve the right to ban you on their own terms.</b> They will be held to scrutiny from the rest of the team and you can always appeal, but ultimately they're trusted to run the server.
-</tr></td>
-</body>
-</html>
+<div>
+<ul>
+<li>- <strong>No mass-murder, bombings, floodings, etc by non-antagonists.</strong> This is griefing and will be dealt with accordingly.</li>
+<br>
+<li>- <strong>RP is enforced.</strong> No netspeak, meme spam, blatant OOC in IC, metagaming, metacommunications or patently absurd character concepts. This -is- SS13, so some leeway for strange or surreal concepts is allowed, but if you are unclear on something in this list, ask an admin.</li>
+<br>
+<li>- <strong>No ERP (cybersex).</strong> This extends to excessive public displays of affection like making out or grinding. We don't care how realistic it is for people on a colony to bump uglies.</li>
+<br>
+<li>- <strong>You are expected to be competent at a job that you sign up for.</strong> This doesn't mean people learning a job are unwelcome, but if you join as a doctor with no understanding of any aspect of medicine you can expect a jobban.</li>
+<br>
+<li>- <strong>Racism, sexism, questionable content and spamming on OOC mediums are not appreciated.</strong> If you're saying something you wouldn't in public, do it at your own peril.</li>
+<br>
+<li>- <strong>Admins reserve the right to ban you on their own terms.</strong> They will be held to scrutiny from the rest of the team and you can always appeal, but ultimately they're trusted to run the server.</li>
+</ul>
+</div>

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -26,6 +26,7 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 /datum/map
 	var/name = "Unnamed Map"
 	var/full_name = "Unnamed Map"
+	var/motd
 	proc/setup_map()
 	var/path
 	var/votable = FALSE
@@ -89,6 +90,9 @@ var/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		map_levels = station_levels.Copy()
 	if(!allowed_jobs)
 		allowed_jobs = subtypesof(/datum/job)
+	motd = 	{"The current map is [full_name].
+			<br>
+			There is no specific information for this map."}
 
 // Used to apply various post-compile procedural effects to the map.
 /datum/map/proc/perform_map_generation()


### PR DESCRIPTION
This window must be closed to continue to the normal menu, and basically consists of the MOTD + Rules + Map info + some useful links. Various config changes etc. made as a result, examples should be provided. Doesn't include actual configs or MOTD I tested with. When/if this goes through I'll throw them Zuh's way or whatever.

A global list (ew I know) is used to check which ckeys have pressed the button so you only see it once per round. It's also available as a Server Information verb in the OOC tab.

The idea behind this is that it can be used to show current info, event info, map-specific info, or whatever, as well as preventing "I didn't read the rules" as an excuse because you literally have to click a button on a page showing you the rules to continue.
