### PR TITLE
Fix world.sleep_offline being set too early

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -103,10 +103,6 @@
 
 	. = ..()
 
-#ifndef UNIT_TEST
-	sleep_offline = 1
-#endif
-
 	// Set up roundstart seed list.
 	plant_controller = new()
 


### PR DESCRIPTION
Meant to delete this in #579, musta forgot.

This is set by the MC now so that subsystems can still initialize even if there's no players. (master.dm:181)