### PR TITLE
Fix/implement shift-click SS monitoring

### DIFF
--- a/code/controllers/master/admin.dm
+++ b/code/controllers/master/admin.dm
@@ -35,12 +35,12 @@
 
 	var/list/paramlist = params2list(params)
 	if (paramlist["shift"] && permit_mark && target)
-		/*if (target in usr.client.holder.watched_processes)
-			usr << "notice", "<span class='notice'>[target] removed from watchlist.</span>"
+		if (target in usr.client.holder.watched_processes)
+			usr << "<span class='notice'>[target] removed from watchlist.</span>"
 			LAZYREMOVE(usr.client.holder.watched_processes, target)
 		else
 			usr << "<span class='notice'>[target] added to watchlist.</span>"
-			LAZYADD(usr.client.holder.watched_processes, target)*/
+			LAZYADD(usr.client.holder.watched_processes, target)
 	else
 		usr.client.debug_variables(target)
 		message_admins("Admin [key_name_admin(usr)] is debugging the [target] [class].")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -697,6 +697,15 @@
 				stat("CPU:","[world.cpu]")
 				stat("Tick Usage:", world.tick_usage)
 				stat("Instances:","[world.contents.len]")
+
+				if (LAZYLEN(client.holder.watched_processes))
+					for (var/thing in client.holder.watched_processes)
+						if (!thing)
+							LAZYREMOVE(client.holder.watched_processes, thing)
+						else
+							var/datum/controller/subsystem/SS = thing
+							SS.stat_entry()
+
 			if(statpanel("MC"))
 				if(Master)
 					Master.stat_entry()


### PR DESCRIPTION
Uncomments/fixes subsystem watching - clients with holders can shift-click on subsystems in the MC panel to add them to the Status panel so individual subsystems can be monitored without having to have the extremely laggy MC panel open.