### PR TITLE
Ammo fabricator changes.

### DIFF
--- a/code/game/machinery/lathes/autolathe.dm
+++ b/code/game/machinery/lathes/autolathe.dm
@@ -14,8 +14,8 @@
 	var/base_icon = "autolathe"
 	var/lathe_type = LATHE_TYPE_GENERIC
 	var/list/machine_recipes
-	var/list/stored_material =  list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
-	var/list/storage_capacity = list(DEFAULT_WALL_MATERIAL = 0, "glass" = 0)
+	var/list/stored_material =  list("steel" = 0, "glass" = 0, "plastic" = 0)
+	var/list/storage_capacity = list("steel" = 0, "glass" = 0, "plastic" = 0)
 	var/show_category = "All"
 
 	var/hacked = 0
@@ -240,9 +240,14 @@
 
 		//Create the desired item.
 		var/obj/item/I = new making.path(loc)
-		if(multiplier > 1 && istype(I, /obj/item/stack))
+		if(istype(I, /obj/item/stack))
 			var/obj/item/stack/S = I
 			S.amount = multiplier
+		else
+			multiplier--
+			while(multiplier > 0)
+				new making.path(loc)
+				multiplier--
 
 	updateUsrDialog()
 

--- a/code/game/machinery/lathes/autolathe_types.dm
+++ b/code/game/machinery/lathes/autolathe_types.dm
@@ -5,6 +5,7 @@
 	lathe_type = LATHE_TYPE_ROBOTICS
 	stored_material =  list("steel" = 0, "glass" = 0, "gold" = 0, "plastic" = 0, "osmium" = 0)
 	storage_capacity = list("steel" = 0, "glass" = 0, "gold" = 0, "plastic" = 0, "osmium" = 0)
+	build_time = 60
 
 /obj/machinery/autolathe/robotics/RefreshParts()
 	..()
@@ -18,6 +19,7 @@
 	lathe_type = LATHE_TYPE_CIRCUIT
 	stored_material =  list("glass" = 0, "gold" = 0)
 	storage_capacity = list("glass" = 0, "gold" = 0)
+	build_time = 45
 
 /obj/machinery/autolathe/advanced
 	name = "device fabricator"
@@ -26,6 +28,7 @@
 	lathe_type = LATHE_TYPE_ADVANCED
 	stored_material =  list("steel" = 0, "glass" = 0, "gold" = 0, "silver" = 0, "plastic" = 0, "osmium" = 0, "uranium" = 0, "diamond" = 0)
 	storage_capacity = list("steel" = 0, "glass" = 0, "gold" = 0, "silver" = 0, "plastic" = 0, "osmium" = 0, "uranium" = 0, "diamond" = 0)
+	build_time = 35
 
 /obj/machinery/autolathe/heavy
 	name = "heavy fabricator"
@@ -36,6 +39,7 @@
 	lathe_type = LATHE_TYPE_HEAVY
 	stored_material =  list("steel" = 0, "plastic" = 0, "osmium" = 0)
 	storage_capacity = list("steel" = 0, "plastic" = 0, "osmium" = 0)
+	build_time = 75
 
 // Heavy fabs need a LOT of materials.
 /obj/machinery/autolathe/heavy/RefreshParts()
@@ -50,3 +54,4 @@
 	lathe_type = LATHE_TYPE_AMMUNITION
 	stored_material =  list("steel" = 0, "osmium" = 0, "plastic" = 0)
 	storage_capacity = list("steel" = 0, "osmium" = 0, "plastic" = 0)
+	build_time = 30

--- a/code/game/machinery/lathes/designs/designs.dm
+++ b/code/game/machinery/lathes/designs/designs.dm
@@ -49,7 +49,7 @@ var/list/autolathe_ammo =     list()
 	var/hidden
 	var/category
 	var/power_use = 0
-	var/is_stack
+	var/multiple_product
 	var/lathe_type = LATHE_TYPE_GENERIC
 
 /datum/autolathe/recipe/bucket
@@ -176,25 +176,25 @@ var/list/autolathe_ammo =     list()
 	name = "steel sheets"
 	path = /obj/item/stack/material/steel
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/glass
 	name = "glass sheets"
 	path = /obj/item/stack/material/glass
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/rglass
 	name = "reinforced glass sheets"
 	path = /obj/item/stack/material/glass/reinforced
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/rods
 	name = "metal rods"
 	path = /obj/item/stack/rods
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/knife
 	name = "kitchen knife"
@@ -389,21 +389,73 @@ var/list/autolathe_ammo =     list()
 	category = "General"
 
 /datum/autolathe/recipe/magazine
-	name = "empty magazine (assault rifle)"
+	name = "empty magazine (assault rifle, .223)"
 	path = /obj/item/ammo_magazine/assault/empty
 	category = "Ammunition"
 
+/datum/autolathe/recipe/magazine/large_rifle
+	name = "empty magazine (assault rifle, .308)"
+	path = /obj/item/ammo_magazine/assault/large/empty
+
 /datum/autolathe/recipe/magazine/pistol
-	name = "empty magazine (pistol)"
+	name = "empty magazine (pistol, 5.7mm)"
 	path = /obj/item/ammo_magazine/pistol/empty
 
+/datum/autolathe/recipe/magazine/pistol/medium
+	name = "empty magazine (pistol, 9mm)"
+	path = /obj/item/ammo_magazine/pistol/medium/empty
+
+/datum/autolathe/recipe/magazine/pistol/large
+	name = "empty magazine (pistol, 10mm)"
+	path = /obj/item/ammo_magazine/pistol/large/empty
+
+/datum/autolathe/recipe/magazine/pistol/a38
+	name = "empty magazine (pistol, .38)"
+	path = /obj/item/ammo_magazine/pistol/a38/empty
+
+/datum/autolathe/recipe/magazine/pistol/a45
+	name = "empty magazine (pistol, .45)"
+	path = /obj/item/ammo_magazine/pistol/a45/empty
+
 /datum/autolathe/recipe/magazine/smg
-	name = "empty magazine (submachine gun)"
+	name = "empty magazine (submachine gun, 5.7mm)"
 	path = /obj/item/ammo_magazine/submachine/empty
 
+/datum/autolathe/recipe/magazine/smg/medium
+	name = "empty magazine (submachine gun, 9mm)"
+	path = /obj/item/ammo_magazine/submachine/medium/empty
+
+/datum/autolathe/recipe/magazine/smg/large
+	name = "empty magazine (submachine gun, 10mm)"
+	path = /obj/item/ammo_magazine/submachine/large/empty
+
+/datum/autolathe/recipe/magazine/smg/a38
+	name = "empty magazine (submachine gun, .38)"
+	path = /obj/item/ammo_magazine/submachine/a38/empty
+
+/datum/autolathe/recipe/magazine/smg/a45
+	name = "empty magazine (submachine gun, .45)"
+	path = /obj/item/ammo_magazine/submachine/a45/empty
+
 /datum/autolathe/recipe/magazine/speedloader
-	name = "empty speedloader (pistol)"
+	name = "empty speedloader (.357)"
 	path = /obj/item/ammo_magazine/speedloader/empty
+
+/datum/autolathe/recipe/magazine/speedloader/a38
+	name = "empty speedloader (.38)"
+	path = /obj/item/ammo_magazine/speedloader/a38/empty
+
+/datum/autolathe/recipe/magazine/speedloader/a45
+	name = "empty speedloader (.45)"
+	path = /obj/item/ammo_magazine/speedloader/a45/empty
+
+/datum/autolathe/recipe/magazine/speedloader/a50
+	name = "empty speedloader (.50 AE)"
+	path = /obj/item/ammo_magazine/speedloader/a50/empty
+
+/datum/autolathe/recipe/magazine/speedloader/caps
+	name = "empty speedloader (caps)"
+	path = /obj/item/ammo_magazine/speedloader/caps/empty
 
 /datum/autolathe/recipe/magazine/autocannon
 	name = "ammunition belt (autocannon)"

--- a/code/game/machinery/lathes/designs/designs_ammo.dm
+++ b/code/game/machinery/lathes/designs/designs_ammo.dm
@@ -1,14 +1,14 @@
 /datum/autolathe/recipe/ammo
-	name = "ammunition (slug, shotgun)"
+	name = "cartridge, 12 gauge"
 	path = /obj/item/ammo_casing/shotgun
 	category = "Shotgun Ammunition"
 	lathe_type = LATHE_TYPE_AMMUNITION
+	multiple_product = 1
 
 /datum/autolathe/recipe/ammo/sheet
 	name = "steel sheets"
 	path = /obj/item/stack/material/steel
 	category = "General"
-	is_stack = 1
 
 /datum/autolathe/recipe/ammo/sheet/plastic
 	name = "plastic sheets"
@@ -19,62 +19,62 @@
 	path = /obj/item/stack/material/osmium
 
 /datum/autolathe/recipe/ammo/beanbag
-	name = "ammunition (beanbag, shotgun)"
+	name = "cartridge, beanbag"
 	path = /obj/item/ammo_casing/shotgun/beanbag
 
 /datum/autolathe/recipe/ammo/pellet
-	name = "ammunition (pellet, shotgun)"
+	name = "cartridge, pellet"
 	path = /obj/item/ammo_casing/shotgun/pellet
 
 /datum/autolathe/recipe/ammo/pistol
-	name = "ammunition (5.7mm, pistol)"
+	name = "bullet, 5.7mm"
 	path = /obj/item/ammo_casing/pistol_small
 	category = "Pistol Ammunition"
 
 /datum/autolathe/recipe/ammo/pistol/medium
-	name = "ammunition (9mm, pistol)"
+	name = "bullet, 9mm"
 	path = /obj/item/ammo_casing/pistol_medium
 
 /datum/autolathe/recipe/ammo/pistol/large
-	name = "ammunition (10mm, pistol)"
+	name = "bullet, 10mm"
 	path = /obj/item/ammo_casing/pistol_large
 
 /datum/autolathe/recipe/ammo/pistol/a357
-	name = "ammunition (.357, pistol)"
+	name = "bullet, .357"
 	path = /obj/item/ammo_casing/a357
 
 /datum/autolathe/recipe/ammo/pistol/magnum
-	name = "ammunition (.50 AE, pistol)"
+	name = "bullet, .50 AE"
 	path = /obj/item/ammo_casing/magnum
 
 /datum/autolathe/recipe/ammo/pistol/a38
-	name = "ammunition (.38, pistol)"
+	name = "bullet, .38"
 	path = /obj/item/ammo_casing/a38
 
 /datum/autolathe/recipe/ammo/pistol/a45
-	name = "ammunition (.45, pistol)"
+	name = "bullet, .45"
 	path = /obj/item/ammo_casing/a45
 
 /datum/autolathe/recipe/ammo/pistol/capgun
-	name = "ammunition (capgun)"
+	name = "bullet, cap"
 	path = /obj/item/ammo_casing/capgun
 
 /datum/autolathe/recipe/ammo/rifle
-	name = "ammunition (.223, rifle)"
+	name = "bullet, .223"
 	path = /obj/item/ammo_casing/rifle_small
 	category = "Rifle Ammunition"
 
 /datum/autolathe/recipe/ammo/rifle/large
-	name = "ammunition (.305, rifle)"
+	name = "bullet, .305"
 	path = /obj/item/ammo_casing/rifle_large
 
 /datum/autolathe/recipe/ammo/rifle/sniper
-	name = "ammunition (.50 BMG, rifle)"
+	name = "bullet, .50 BMG"
 	path = /obj/item/ammo_casing/sniper
 	hidden = 1
 
 /datum/autolathe/recipe/ammo/gyrojet
-	name = "ammunition (20mm, gyrojet)"
+	name = "gyrojet shell, 20mm"
 	path = /obj/item/ammo_casing/gyrojet
 	category = "Cannon Ammunition"
 	hidden = 1

--- a/code/game/machinery/lathes/designs/designs_circuits.dm
+++ b/code/game/machinery/lathes/designs/designs_circuits.dm
@@ -173,10 +173,10 @@
 	name = "glass sheets"
 	path = /obj/item/stack/material/glass
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/circuit/gold
 	name = "gold ingots"
 	path = /obj/item/stack/material/gold
 	category = "General"
-	is_stack = 1
+	multiple_product = 1

--- a/code/game/machinery/lathes/designs/designs_heavy.dm
+++ b/code/game/machinery/lathes/designs/designs_heavy.dm
@@ -46,7 +46,7 @@
 	name = "steel sheets"
 	path = /obj/item/stack/material/steel
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/heavy/sheet/plastic
 	name = "plastic sheets"

--- a/code/game/machinery/lathes/designs/designs_robotics.dm
+++ b/code/game/machinery/lathes/designs/designs_robotics.dm
@@ -7,7 +7,7 @@
 /datum/autolathe/recipe/robotics/nanopaste
 	name = "nanopaste"
 	path = /obj/item/stack/nanopaste
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/robotics/arm
 	name = "left arm"
@@ -62,7 +62,7 @@
 	name = "steel sheets"
 	path = /obj/item/stack/material/steel
 	category = "General"
-	is_stack = 1
+	multiple_product = 1
 
 /datum/autolathe/recipe/robotics/sheet/plastic
 	name = "plastic sheets"

--- a/code/modules/europa/guns/ammo/ammo_magazine.dm
+++ b/code/modules/europa/guns/ammo/ammo_magazine.dm
@@ -21,17 +21,17 @@
 
 /obj/item/ammo_magazine/New()
 	..()
+
 	if(isnull(initial_ammo))
 		initial_ammo = max_ammo
-	if(initial_ammo)
-		caliber = null
-		for(var/i = 1 to initial_ammo)
-			if(!caliber)
-				var/obj/item/ammo_casing/AC = new ammo_type(src)
-				caliber = AC.caliber
-				stored_ammo += AC
-			else
+
+	if(ammo_type)
+		var/obj/item/ammo_casing/bullet = ammo_type
+		caliber = initial(bullet.caliber)
+		if(initial_ammo)
+			for(var/i = 1 to initial_ammo)
 				stored_ammo += new ammo_type(src)
+
 	name = "[initial(name)] ([caliber])"
 	update_icon()
 
@@ -63,18 +63,6 @@
 /obj/item/ammo_magazine/examine(mob/user)
 	..()
 	user << "<span class='notice'>There [(stored_ammo.len == 1)? "is" : "are"] [stored_ammo.len] round\s left.</span>"
-
-// Empty mags.
-/obj/item/ammo_magazine/assault/empty
-	initial_ammo = 0
-/obj/item/ammo_magazine/pistol/empty
-	initial_ammo = 0
-/obj/item/ammo_magazine/submachine/empty
-	initial_ammo = 0
-/obj/item/ammo_magazine/autocannon/empty
-	initial_ammo = 0
-/obj/item/ammo_magazine/speedloader/empty
-	initial_ammo = 0
 
 // Predefined
 /obj/item/ammo_magazine/assault
@@ -117,3 +105,41 @@
 	name = "ammunition belt"
 	icon_state = "cannon_belt"
 	ammo_type = /obj/item/ammo_casing/gyrojet
+
+// Empty mags.
+/obj/item/ammo_magazine/assault/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/assault/large/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/pistol/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/pistol/medium/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/pistol/large/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/pistol/a38/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/pistol/a45/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/submachine/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/submachine/medium/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/submachine/large/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/submachine/a38/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/submachine/a45/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/autocannon/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/speedloader/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/speedloader/a38/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/speedloader/a45/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/speedloader/a50/empty
+	initial_ammo = 0
+/obj/item/ammo_magazine/speedloader/caps/empty
+	initial_ammo = 0

--- a/code/modules/europa/terminals/term_program_lathe.dm
+++ b/code/modules/europa/terminals/term_program_lathe.dm
@@ -1,3 +1,5 @@
+#define MAX_ITEMS_PER_PRINT 20
+
 /datum/console_program/lathe
 	name = "lathe module"
 	var/obj/machinery/autolathe/lathe
@@ -94,11 +96,14 @@
 					if(!isnull(lathe.stored_material[material]) && lathe.stored_material[material] < round(R.resources[material]*lathe.mat_efficiency))
 						can_make = 0
 					material_string += "[round(R.resources[material] * lathe.mat_efficiency)][copytext(material,1,3)] "
+					max_sheets = min(max_sheets, MAX_ITEMS_PER_PRINT)
 
 				//Build list of multipliers for sheets.
-				if(R.is_stack)
+				if(R.multiple_product)
 					if(max_sheets && max_sheets > 0)
 						for(var/scount = 5;scount<max_sheets;scount*=2) //5,10,20,40...
+							if(scount >= MAX_ITEMS_PER_PRINT)
+								break
 							multiplier_string  += "<a href='?src=\ref[lathe];make=[recipes_to_display[R]];multiplier=[scount]'>\[x[scount]\]</a>"
 							pad_count -= length("[scount]")+3
 						multiplier_string += "<a href='?src=\ref[lathe];make=[recipes_to_display[R]];multiplier=[max_sheets]'>\[x[max_sheets]\]</a>"
@@ -126,3 +131,5 @@
 			html += "[adding] [material_string]"
 
 	..(silent)
+
+#undef MAX_ITEMS_PER_PRINT


### PR DESCRIPTION
- Fabricators can now print out arbitrary multiples instead of only sheets.
- Max multiple for fabs is now 20.
- Ammunition can be printed en masse.
- Fabrication times tweaked.
- Regular lathe can now print all appropriate empty magazines.
- Magazines set their caliber from expected contents even in the absence of initial ammo.