### PR TITLE
Fix infinite while loop in chemistry

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -172,7 +172,7 @@
 
 			if(reagents.total_volume/count < 1) //Sanity checking.
 				return
-			while (count--)
+			while (count-- && count >= 0)
 				var/obj/item/reagent_containers/pill/P = new/obj/item/reagent_containers/pill(src.loc)
 				if(pill_label)
 					P.desc = "A pill. It is labelled with '[pill_label]' in tiny text."


### PR DESCRIPTION
PR stolen from [here.](https://github.com/Baystation12/Baystation12/pull/20280)

This fixes a terrible bug that can crash dream daemon without any hassle.