### PR TITLE
Removes some ladder requirements

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -26,8 +26,6 @@
 			if(L.allowed_directions & UP)
 				target_down = L
 				L.target_up = src
-				var/turf/T = get_turf(src)
-				T.ReplaceWithLattice()
 				return
 	update_icon()
 
@@ -94,7 +92,7 @@
 	instant_climb(M)
 
 /obj/structure/ladder/proc/getTargetLadder(var/mob/M)
-	if((!target_up && !target_down) || (target_up && !istype(target_up.loc, /turf/simulated/open) || (target_down && !istype(target_down.loc, /turf))))
+	if((!target_up && !target_down) || (target_down && !istype(target_down.loc, /turf)))
 		to_chat(M, "<span class='notice'>\The [src] is incomplete and can't be climbed.</span>")
 		return
 	if(target_down && target_up)


### PR DESCRIPTION
Removes the requirement for ladders to be on open space to correctly link with the ladders below, and stops them adding lattice to the tile they're on. Ladder pairs should now function on any terrain they're placed on.
This allows ladders to be used between 2 Z-levels that have no open space and no default base turfs of open space, so you can have Z-levels which are ladder-traversable whilst still being further apart than just sat on top of each other.
