### PR TITLE
Port old server info screen

### DIFF
--- a/code/_global_vars/configuration.dm
+++ b/code/_global_vars/configuration.dm
@@ -3,7 +3,7 @@ GLOBAL_VAR_INIT(max_explosion_range, 14)
 
 
 var/href_logfile        = null
-var/game_version        = "Baystation12"
+var/game_version        = "Cassini"
 var/changelog_hash      = ""
 var/game_year           = (text2num(time2text(world.realtime, "YYYY")) + 544)
 var/join_motd = null

--- a/code/_global_vars/mobs.dm
+++ b/code/_global_vars/mobs.dm
@@ -2,7 +2,7 @@ GLOBAL_LIST_EMPTY(clients)   //all clients
 GLOBAL_LIST_EMPTY(admins)    //all clients whom are admins
 GLOBAL_PROTECT(admins)
 GLOBAL_LIST_EMPTY(ckey_directory) //all ckeys with associated client
-
+GLOBAL_LIST_EMPTY(acceptedKeys) //all ckeys which have pressed the "I accept joining the server" button
 
 GLOBAL_LIST_EMPTY(player_list)      //List of all mobs **with clients attached**. Excludes /mob/new_player
 GLOBAL_LIST_EMPTY(human_mob_list)   //List of all human mobs and sub-types, including clientless

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -97,6 +97,8 @@ var/list/gamemode_cache = list()
 	var/wikiurl
 	var/forumurl
 	var/githuburl
+	var/upstreamurl
+	var/upstream
 	var/issuereporturl
 
 	var/forbid_singulo_possession = 0
@@ -431,6 +433,12 @@ var/list/gamemode_cache = list()
 
 				if ("githuburl")
 					config.githuburl = value
+
+				if ("upstreamurl")
+					config.upstreamurl = value
+
+				if ("upstream")
+					config.upstream = value
 
 				if ("issuereporturl")
 					config.issuereporturl = value

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -17,6 +17,8 @@
 
 	var/adminhelped = 0
 
+	var/datum/browser/infowindow
+
 	var/staffwarn = null
 
 		///////////////

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -22,9 +22,7 @@
 
 /mob/new_player/Login()
 	update_Login_details()	//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
-	if(join_motd)
-		to_chat(src, "<div class=\"motd\">[join_motd]</div>")
-	to_chat(src, "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>")
+	src << "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>"
 
 	if(!mind)
 		mind = new /datum/mind(key)
@@ -37,7 +35,10 @@
 	set_sight(sight|SEE_TURFS)
 	GLOB.player_list |= src
 
-	new_player_panel()
+	if (client.ckey in acceptedKeys) //Check if they've already clicked the I ACCEPT info window thing, each round once.
+		new_player_panel()
+	else
+		client.check_server_info()
 	spawn(40)
 		if(client)
 			handle_privacy_poll()

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -35,7 +35,7 @@
 	set_sight(sight|SEE_TURFS)
 	GLOB.player_list |= src
 
-	if (client.ckey in acceptedKeys) //Check if they've already clicked the I ACCEPT info window thing, each round once.
+	if (client.ckey in GLOB.acceptedKeys) //Check if they've already clicked the I ACCEPT info window thing, each round once.
 		new_player_panel()
 	else
 		client.check_server_info()

--- a/code/modules/mob/new_player/server_info_window.dm
+++ b/code/modules/mob/new_player/server_info_window.dm
@@ -1,0 +1,58 @@
+/client/verb/check_server_info()
+	set name = "Server Information"
+	set category = "OOC"
+
+	if (src.infowindow)  //If the user's already viewed the window before just load it again.
+		src.infowindow.open()
+		return
+
+	var/list/close = list("Gotcha!","AFFIRMATIVE","EXCELSIOR!","I accept","The Pact Is Sealed","Continue","Take me to the fun!","Let us begin")
+	var/output = {"
+	[join_motd]
+	<br>
+	[file2text("config/rules.html")]
+	<p><b>Map info:</b></p>
+	[using_map.motd]
+	<br>
+	<br>
+	<div align='center'>
+	<strong>Useful links:</strong>
+	<br>
+	<b><a href='byond://?src=\ref[src];bugtracker_link=1'>Bugtracker</A></b>
+	<b><a href='byond://?src=\ref[src];wiki_link=1'>Wiki</A></b>
+	<b><a href='byond://?src=\ref[src];forum_link=1'>Forum</A></b>
+	<b><a href='byond://?src=\ref[src];changelog_link=1'>Changelog</A></b>
+	<br>
+	This server is running the [game_version] modification of <a href='byond://?src=\ref[src];upstream_link=1'>[config.upstream]</A>'s SS13 code.
+	<p><b><a href='byond://?src=\ref[src];close_info=1'>[pick(close)]</A></b></p>
+	</div>"}
+	infowindow = new(src.mob, "Welcome to [game_version]","Welcome to [game_version]", 768, 768, src)
+	infowindow.set_window_options("can_close=0")
+	infowindow.set_content(output)
+	infowindow.open()
+	return
+
+client/Topic(href, href_list[])
+	if(href_list["upstream_link"])
+		src << link(config.upstreamurl)
+
+	if (href_list["bugtracker_link"])
+		src << link(config.githuburl)
+
+	if(href_list["wiki_link"])
+		src.wiki()
+
+	if(href_list["forum_link"])
+		src.forum()
+
+	if(href_list["changelog_link"])
+		src.changes()
+
+	if(href_list["close_info"])
+		src.infowindow.close()
+		if(isnewplayer(src.mob))
+			var/mob/new_player/M = src.mob
+			if(!(src.ckey in acceptedKeys)) //If they've yet to view the info window they must be just joining so we note this then show them the normal menu.
+				M.new_player_panel()
+				acceptedKeys.Add(src.ckey)
+	..()

--- a/code/modules/mob/new_player/server_info_window.dm
+++ b/code/modules/mob/new_player/server_info_window.dm
@@ -12,7 +12,7 @@
 	<br>
 	[file2text("config/rules.html")]
 	<p><b>Map info:</b></p>
-	[using_map.motd]
+	[GLOB.using_map.map_info]
 	<br>
 	<br>
 	<div align='center'>
@@ -52,7 +52,7 @@ client/Topic(href, href_list[])
 		src.infowindow.close()
 		if(isnewplayer(src.mob))
 			var/mob/new_player/M = src.mob
-			if(!(src.ckey in acceptedKeys)) //If they've yet to view the info window they must be just joining so we note this then show them the normal menu.
+			if(!(src.ckey in GLOB.acceptedKeys)) //If they've yet to view the info window they must be just joining so we note this then show them the normal menu.
 				M.new_player_panel()
-				acceptedKeys.Add(src.ckey)
+				GLOB.acceptedKeys.Add(src.ckey)
 	..()

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -206,10 +206,10 @@ GUEST_BAN
 # GITHUBURL https://github.com/example-user/example-repository
 
 ## Upstream Github address - just for things like "This is a modified fork of [Baystation]"
-# UPSTREAMURL https://github.com/example-user/example-repository
+UPSTREAMURL https://github.com/Baystation12/Baystation12/
 
 ## Upstream name
-# UPSTREAM Baystation12
+UPSTREAM Baystation12
 
 ## GitHub new issue address
 # ISSUEREPORTURL https://github.com/example-user/example-repository/issues/new

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -205,6 +205,12 @@ GUEST_BAN
 ## GitHub address
 # GITHUBURL https://github.com/example-user/example-repository
 
+## Upstream Github address - just for things like "This is a modified fork of [Baystation]"
+# UPSTREAMURL https://github.com/example-user/example-repository
+
+## Upstream name
+# UPSTREAM Baystation12
+
 ## GitHub new issue address
 # ISSUEREPORTURL https://github.com/example-user/example-repository/issues/new
 

--- a/config/example/motd.txt
+++ b/config/example/motd.txt
@@ -1,4 +1,4 @@
-<div align='center'><h1>Welcome to Europa, colonist.</h1></div>
+<div align='center'><h1>Welcome to Cassini, colonist.</h1></div>
 <br>
 <div>
 <strong>By continuing you agree to read the rules below</strong> and get familiar with our roleplaying expectations before diving in.

--- a/config/example/motd.txt
+++ b/config/example/motd.txt
@@ -1,5 +1,7 @@
-<h1>Welcome to Space Station 13!</h1>
+<div align='center'><h1>Welcome to Europa, colonist.</h1></div>
+<br>
+<div>
+<strong>By continuing you agree to read the rules below</strong> and get familiar with our roleplaying expectations before diving in.
+</div>
 
--<i>This server is running <a href="http://baystation12.net/">Baystation 12's</a> modification of the <a href="http://ss13.eu/">/tg/station13</a> SS13 code.</i>
-<br><br>
-<strong>Bugtracker:</strong> <a href="http://baystation12.net/forums/threads/issue-tracker-report-template.110/">for posting of bugs and issues.</a>
+<br>

--- a/config/example/rules.html
+++ b/config/example/rules.html
@@ -1,11 +1,15 @@
-<html>
-<head><title>Server Rules</title></head>
-<body>
-
-<!--
-Example: baystation12 rules embed.
-<iframe width='100%' height='100%' src="http://wiki.baystation12.net/index.php?title=Rules&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
--->
-
-</body>
-</html>
+<div>
+<ul>
+<li>- <strong>No mass-murder, bombings, floodings, etc by non-antagonists.</strong> This is griefing and will be dealt with accordingly.</li>
+<br>
+<li>- <strong>RP is enforced.</strong> No netspeak, meme spam, blatant OOC in IC, metagaming, metacommunications or patently absurd character concepts. This -is- SS13, so some leeway for strange or surreal concepts is allowed, but if you are unclear on something in this list, ask an admin.</li>
+<br>
+<li>- <strong>No ERP (cybersex).</strong> This extends to excessive public displays of affection like making out or grinding. We don't care how realistic it is for people on a colony to bump uglies.</li>
+<br>
+<li>- <strong>You are expected to be competent at a job that you sign up for.</strong> This doesn't mean people learning a job are unwelcome, but if you join as a doctor with no understanding of any aspect of medicine you can expect a jobban.</li>
+<br>
+<li>- <strong>Racism, sexism, questionable content and spamming on OOC mediums are not appreciated.</strong> If you're saying something you wouldn't in public, do it at your own peril.</li>
+<br>
+<li>- <strong>Admins reserve the right to ban you on their own terms.</strong> They will be held to scrutiny from the rest of the team and you can always appeal, but ultimately they're trusted to run the server.</li>
+</ul>
+</div>

--- a/config/example/rules.html
+++ b/config/example/rules.html
@@ -6,7 +6,7 @@
 <br>
 <li>- <strong>No ERP (cybersex).</strong> This extends to excessive public displays of affection like making out or grinding. We don't care how realistic it is for people on a colony to bump uglies.</li>
 <br>
-<li>- <strong>You are expected to be competent at a job that you sign up for.</strong> This doesn't mean people learning a job are unwelcome, but if you join as a doctor with no understanding of any aspect of medicine you can expect a jobban.</li>
+<li>- <strong>You are expected to perform the job that you sign up for.</strong> This doesn't mean people learning a job are unwelcome, but if you join as a doctor and intend to do nothing all round but hide in maintenance, you can expect a jobban.</li>
 <br>
 <li>- <strong>Racism, sexism, questionable content and spamming on OOC mediums are not appreciated.</strong> If you're saying something you wouldn't in public, do it at your own peril.</li>
 <br>

--- a/maps/~mapsystem/maps.dm
+++ b/maps/~mapsystem/maps.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(all_maps)
 /datum/map
 	var/name = "Unnamed Map"
 	var/full_name = "Unnamed Map"
+	var/map_info = "This map has no specific information"
 	var/path
 
 	var/list/station_levels = list() // Z-levels the station exists on


### PR DESCRIPTION
Ports my old server info screen. Cherrypicks the original commit and makes some changes where necessary due to changed structure in the intervening years.
Also updates a few config settings and example config files.

If there are better places to put the globals or I've gone particularly against convention, let me know.