### PR TITLE
Fixes damage overlays

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -40,7 +40,7 @@
 	if(!material)
 		return
 
-	if(LAZYLEN(damage_overlays) < 1) //list hasn't been populated
+	if(!damage_overlays[1]) //list hasn't been populated
 		generate_overlays()
 
 	// This line apparently causes runtimes during initialization.


### PR DESCRIPTION
Accidentally introduced in Baystation12/Baystation12#24112 ?
Damage overlays would never be populated because it's already an empty 16 length array.