### PR TITLE
Cherrypicks fix from Bay for login issues

### DIFF
--- a/code/controllers/subsystems/initialization/character_setup.dm
+++ b/code/controllers/subsystems/initialization/character_setup.dm
@@ -5,10 +5,15 @@ SUBSYSTEM_DEF(character_setup)
 
 	var/list/prefs_awaiting_setup = list()
 	var/list/preferences_datums = list()
+	var/list/newplayers_requiring_init = list()
 
 /datum/controller/subsystem/character_setup/Initialize()
 	while(prefs_awaiting_setup.len)
 		var/datum/preferences/prefs = prefs_awaiting_setup[prefs_awaiting_setup.len]
 		prefs_awaiting_setup.len--
 		prefs.setup()
+	while(newplayers_requiring_init.len)
+		var/mob/new_player/new_player = newplayers_requiring_init[newplayers_requiring_init.len]
+		newplayers_requiring_init.len--
+		new_player.deferred_login()
 	. = ..()

--- a/code/modules/client/preferences_toggle.dm
+++ b/code/modules/client/preferences_toggle.dm
@@ -4,6 +4,8 @@ var/list/client_preference_stats_
 	. = list()
 	if(!user)
 		return
+	if(!SScharacter_setup.initialized)
+		return
 	if(!client_preference_stats_)
 		client_preference_stats_ = list()
 		for(var/datum/client_preference/client_pref in get_client_preferences())

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -35,19 +35,27 @@
 	set_sight(sight|SEE_TURFS)
 	GLOB.player_list |= src
 
-	if (client.ckey in GLOB.acceptedKeys) //Check if they've already clicked the I ACCEPT info window thing, each round once.
-		new_player_panel()
+	if(!SScharacter_setup.initialized)
+		SScharacter_setup.newplayers_requiring_init += src
 	else
-		client.check_server_info()
-	spawn(40)
-		if(client)
-			handle_privacy_poll()
-			client.playtitlemusic()
-			maybe_send_staffwarns("connected as new player")
+		deferred_login()
 
-		var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
-		var/decl/security_level/SL = security_state.current_security_level
-		var/alert_desc = ""
-		if(SL.up_description)
-			alert_desc = SL.up_description
-		to_chat(usr, "<span class='notice'>The alert level on [station_name()] is currently: <font color=[SL.light_color_alarm]><B>[SL.name]</B></font>. [alert_desc]</span>")
+// This is called when the charcter setup system has been sufficiently initialized and prefs are available.
+// Do not make any calls in mob/Login which may require prefs having been loaded.
+// It is safe to assume that any UI or sound related calls will fall into that category.
+/mob/new_player/proc/deferred_login()
+	if(client)
+		if (client.ckey in GLOB.acceptedKeys) //Check if they've already clicked the I ACCEPT info window thing, each round once.
+			new_player_panel()
+		else
+			client.check_server_info()
+		handle_privacy_poll()
+		client.playtitlemusic()
+		maybe_send_staffwarns("connected as new player")
+
+	var/decl/security_state/security_state = decls_repository.get_decl(GLOB.using_map.security_state)
+	var/decl/security_level/SL = security_state.current_security_level
+	var/alert_desc = ""
+	if(SL.up_description)
+		alert_desc = SL.up_description
+	to_chat(src, "<span class='notice'>The alert level on the [station_name()] is currently: <font color=[SL.light_color_alarm]><B>[SL.name]</B></font>. [alert_desc]</span>")


### PR DESCRIPTION
Fix prevents preference-related activity before subsystem can finish initializing prefs.
This issue became apparent to me due to our info window that requires the browser pref and would cause a runtime if the user connects just as the server is starting up or remains connected over a restart.
Some further problems related have been identified as a result, and will be fixed in future PRs.

Credit to @afterthought2 