### PR TITLE
Makes the info window/new player panel a bit more robust

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -313,3 +313,5 @@ block( \
 #define GET_BELOW(A) (HAS_BELOW(A:z) ? get_step(A, DOWN) : null)
 
 #define isopenturf(T) istype(T, /turf/simulated/open)
+
+#define NEW_PLAYER_PANEL_ID "NewPlayerPanel"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -50,9 +50,6 @@ datum/preferences
 		load_preferences()
 		load_and_update_character()
 	sanitize_preferences()
-	if(client && istype(client.mob, /mob/new_player))
-		var/mob/new_player/np = client.mob
-		np.new_player_panel(TRUE)
 
 /datum/preferences/proc/load_and_update_character(var/slot)
 	load_character(slot)

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -35,6 +35,15 @@
 	set_sight(sight|SEE_TURFS)
 	GLOB.player_list |= src
 
+	/*
+	 * We need to ensure the new player panel isn't still open if the server has restarted without the client disconnecting!
+	 * Otherwise the panel will still be open once the server restarts, and the user may be left with a non-responsive panel.
+	 * We have to close the window by manually browsing null on the same windowid, because we may no longer have the reference.
+	 * (It's null, but the client is still showing it, and it's unresponsive)
+ 	 */
+	close_browser(src, "window=[NEW_PLAYER_PANEL_ID]")
+	//And now the client will magically see the panel disappear.
+
 	if(!SScharacter_setup.initialized)
 		SScharacter_setup.newplayers_requiring_init += src
 	else

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -63,7 +63,7 @@
 
 	output += "</div>"
 
-	panel = new(src, "Welcome","Welcome", 210, 280, src)
+	panel = new(src, NEW_PLAYER_PANEL_ID,"Welcome", 210, 280, src)
 	panel.set_window_options("can_close=0")
 	panel.set_content(JOINTEXT(output))
 	panel.open()


### PR DESCRIPTION
Removes 1 call to show the new player panel which I'm certain is defunct and should not be occurring (on pref setup), to prevent the panel appearing when the player still has the server info window open.
Forcibly closes the new player panel when the client logs in, to ensure that it cannot be open (it would remain open if it already was and the player was connected over the server restart, at which point it would break).
Adds a global definition of the player panel window ID so that we're sure we're creating and closing the same window ID.

Suggestions of other ways to do this very welcome.