### PR TITLE
Updates decals to fix issues with AO

### DIFF
--- a/code/__defines/_planes+layers.dm
+++ b/code/__defines/_planes+layers.dm
@@ -110,12 +110,15 @@ What is the naming convention for planes or layers?
 	#define BLOOD_LAYER                 9
 	#define MOUSETRAP_LAYER             10
 	#define PLANT_LAYER                 11
+	#define AO_LAYER            		12
 
 #define HIDING_MOB_PLANE              -16 // for hiding mobs like MoMMIs or spiders or whatever, under most objects but over pipes & such.
 
 	#define HIDING_MOB_LAYER    0
 	#define SHALLOW_FLUID_LAYER 1
+
 #define OBJ_PLANE                     -15 // For objects which appear below humans.
+
 	#define BELOW_DOOR_LAYER        0.25
 	#define OPEN_DOOR_LAYER         0.5
 	#define BELOW_TABLE_LAYER       0.75

--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -32,7 +32,7 @@ var/list/floor_decals = list()
 			floor_decals[cache_key] = I
 		if(!T.decals) T.decals = list()
 		T.decals |= floor_decals[cache_key]
-		T.overlays |= floor_decals[cache_key]
+		T.add_overlay(floor_decals[cache_key])
 	atom_flags |= ATOM_FLAG_INITIALIZED
 	return INITIALIZE_HINT_QDEL
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -47,7 +47,7 @@
 //This proc auto corrects the grass tiles' siding.
 /turf/simulated/floor/proc/make_plating(var/place_product, var/defer_icon_update)
 
-	overlays.Cut()
+	cut_overlays()
 
 	for(var/obj/effect/decal/writing/W in src)
 		qdel(W)

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -23,40 +23,40 @@ var/list/flooring_cache = list()
 				flooring_override = icon_state
 
 		// Apply edges, corners, and inner corners.
-		overlays.Cut()
+		cut_overlays()
 		var/has_border = 0
 		if(flooring.flags & TURF_HAS_EDGES)
 			for(var/step_dir in GLOB.cardinal)
 				var/turf/simulated/floor/T = get_step(src, step_dir)
 				if(!istype(T) || !T.flooring || T.flooring.name != flooring.name)
 					has_border |= step_dir
-					overlays |= get_flooring_overlay("[flooring.icon_base]-edge-[step_dir]", "[flooring.icon_base]_edges", step_dir)
+					add_overlay(get_flooring_overlay("[flooring.icon_base]-edge-[step_dir]", "[flooring.icon_base]_edges", step_dir))
 
 			for(var/diagonal in list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
 				if((has_border & diagonal) == diagonal)
-					overlays |= get_flooring_overlay("[flooring.icon_base]-edge-[diagonal]", "[flooring.icon_base]_edges", diagonal)
+					add_overlay(get_flooring_overlay("[flooring.icon_base]-edge-[diagonal]", "[flooring.icon_base]_edges", diagonal))
 				if((has_border & diagonal) == 0 && (flooring.flags & TURF_HAS_CORNERS))
 					var/turf/simulated/floor/T = get_step(src, diagonal)
 					if(!(istype(T) && T.flooring && T.flooring.name == flooring.name))
-						overlays |= get_flooring_overlay("[flooring.icon_base]-corner-[diagonal]", "[flooring.icon_base]_corners", diagonal)
+						add_overlay(get_flooring_overlay("[flooring.icon_base]-corner-[diagonal]", "[flooring.icon_base]_corners", diagonal))
 
 		if(flooring.can_paint && decals && decals.len)
-			overlays |= decals
+			add_overlay(decals)
 
 	else if(decals && decals.len)
 		for(var/image/I in decals)
 			if(I.plane != ABOVE_PLATING_PLANE)
 				continue
-			overlays |= I
+			add_overlay(I)
 
 	if(is_plating() && !(isnull(broken) && isnull(burnt))) //temp, todo
 		icon = 'icons/turf/flooring/plating.dmi'
 		icon_state = "dmg[rand(1,4)]"
 	else if(flooring)
 		if(!isnull(broken) && (flooring.flags & TURF_CAN_BREAK))
-			overlays |= get_damage_overlay("broken[broken]", BLEND_MULTIPLY)
+			add_overlay(get_damage_overlay("broken[broken]", BLEND_MULTIPLY))
 		if(!isnull(burnt) && (flooring.flags & TURF_CAN_BURN))
-			overlays |= get_damage_overlay("burned[burnt]")
+			add_overlay(get_damage_overlay("burned[burnt]"))
 
 	if(update_neighbors)
 		for(var/turf/simulated/floor/F in orange(src, 1))

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -29,6 +29,8 @@
 	var/image/I = image('icons/turf/flooring/shadows.dmi', cstr, dir = 1 << (i-1))
 	I.alpha = WALL_AO_ALPHA
 	I.blend_mode = BLEND_OVERLAY
+	I.plane = ABOVE_TURF_PLANE
+	I.layer = AO_LAYER
 	I.appearance_flags = RESET_ALPHA|RESET_COLOR|TILE_BOUND
 
 	// If there's an offset, counteract it.

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -38,7 +38,7 @@
 
 	if(connections) connections.erase_all()
 
-	overlays.Cut()
+	cut_overlays()
 	underlays.Cut()
 	if(istype(src,/turf/simulated))
 		//Yeah, we're just going to rebuild the whole thing.


### PR DESCRIPTION
AO was overwriting decals because they don't use SSOverlay, and they would then overwrite AO overlays because they don't have a plane/layer.
This adds those, so decals will now correctly render and AO will render on top of them (and various other things).

Before - No decals next to wall where there's AO:
![image](https://user-images.githubusercontent.com/4721936/52308694-e461ee80-2995-11e9-887f-05fb828d95e0.png)

After - AO on top of decals.
![image](https://user-images.githubusercontent.com/4721936/52308721-f9d71880-2995-11e9-9bca-358d0120f3bc.png)
