### PR TITLE
Updates lights to LIGHT_COLOR_HALOGEN and LIGHT_COLOR_TUNGSTEN

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -581,7 +581,7 @@
 	var/broken_chance = 2
 	var/b_power = 0.9
 	var/b_range = 5
-	var/b_color = "#fffee0"
+	var/b_color = LIGHT_COLOR_HALOGEN
 	var/list/lighting_modes = list()
 	var/sound_on
 
@@ -592,7 +592,7 @@
 	base_state = "ltube"
 
 	b_range = 5
-	b_color = "#fffee0"
+	b_color = LIGHT_COLOR_HALOGEN
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_range = 4, l_power = 1, l_color = "#da0205"),
 		)
@@ -623,7 +623,7 @@
 
 	b_power = 0.6
 	b_range = 4
-	b_color = "#fcfcc7"
+	b_color = LIGHT_COLOR_TUNGSTEN
 	lighting_modes = list(
 		LIGHTMODE_EMERGENCY = list(l_range = 3, l_power = 1, l_color = "#da0205"),
 		)


### PR DESCRIPTION
Updates tubes (and the default no-sprite tube) to LIGHT_COLOR_HALOGEN and the bulb to LIGHT_COLOR_TUNGSTEN. The halogen tubes have a cooler feel than current, and the bulbs are slightly warmer, giving a different feel and some enhanced contrast.